### PR TITLE
extended malpedia scanner script with offline mode and working both ways

### DIFF
--- a/scripts/check_malpedia.py
+++ b/scripts/check_malpedia.py
@@ -6,53 +6,96 @@ all given alternative names.
 """
 import argparse
 import csv
+import json
 import re
-import os.path
+import os
 import requests
 import sys
 
 
-filename = 'mapping.csv'
-for path in ['./', '../']:
-    if os.path.exists(os.path.join(path, filename)):
-        filename = os.path.join(path, filename)
-        break
-else:
-    print("File 'mapping.csv' not found in '.' and '..'.", file=sys.stderr)
-    sys.exit(2)
-with open('/home/sebastian/dev/malware_name_mapping/mapping.csv') as handle:
-    mapping = csv.reader(handle)
-    expressions = {line[0] for line in mapping}
+def load_mapping():
+    filename = 'mapping.csv'
+    for path in ['./', '../']:
+        if os.path.exists(os.path.join(path, filename)):
+            filename = os.path.join(path, filename)
+            break
+    else:
+        print("File 'mapping.csv' not found in '.' and '..'.", file=sys.stderr)
+        sys.exit(2)
+    with open(filename) as handle:
+        mapping = csv.reader(handle)
+        expressions = {line[0] for line in mapping}
+    return expressions
 
-parser = argparse.ArgumentParser(
-    prog='check_malpedia',
-    description='Checks if malpedia lists malware names which this mapping does not support.',
-)
 
-parser.add_argument('username',
-                    help='The username to log into malpedia.')
-parser.add_argument('password',
-                    help='The password to log into malpedia.')
-args = parser.parse_args()
-auth = (args.username, args.password)
-families_req = requests.get('https://malpedia.caad.fkie.fraunhofer.de/api/list/families',
-                            auth=auth)
-families_req.raise_for_status()  # missing login
-families = families_req.json()
+def get_malpedia_names_online(username, password):
+    malpedia_names = {}
+    auth = (username, password)
+    families_req = requests.get('https://malpedia.caad.fkie.fraunhofer.de/api/list/families', auth=auth)
+    families_req.raise_for_status()  # missing login
+    for family in families_req.json():
+        if not family.startswith('win') or "unidentified" in family:
+            continue
+        malpedia_names[family] = [family[4:]]
+        malpedia_names[family].extend(requests.get('https://malpedia.caad.fkie.fraunhofer.de/api/get/family/%s' % family, auth=auth).json()['alt_names'])
+    return malpedia_names
 
-for family in families:
-    if not family.startswith('win'):
-        continue
-    altnames = requests.get('https://malpedia.caad.fkie.fraunhofer.de/api/get/family/%s' % family,
-                            auth=auth).json()['alt_names']
-    unmatched_altnames = []
-    for altname in altnames:
-        for rule in expressions:
-            if re.match(rule, altname, re.IGNORECASE):
-                break
-        else:
-            unmatched_altnames.append(altname)
 
-    if unmatched_altnames:
-        print("No mapping for altnames '%s' of malpedia entry %r."
-              "" % ("', '".join(unmatched_altnames), family))
+def get_malpedia_names_offline(path):
+    malpedia_names = {}
+    if not os.path.isdir(path):
+        sys.exit('{} is not a directory'.format(path))
+    for family in os.listdir(path):
+        if not family.startswith('win') or "unidentified" in family:
+            continue
+        malpedia_names[family] = [family[4:]]
+        family_meta = {}
+        with open(os.sep.join([path, family, family + '.json'])) as f_json:
+            family_meta = json.load(f_json)
+        malpedia_names[family].extend(family_meta['alt_names'])
+    return malpedia_names
+
+ 
+def check_mapping_regexes(regexes, malpedia_names):
+    for family, names in malpedia_names.items():
+        unmatched_names = []
+        has_malpedia = False
+        matching_regexes = []
+        for name in names:
+            for rule in regexes:
+                if re.match(rule, name, re.IGNORECASE):
+                    matching_regexes.append(rule)
+                    break
+            else:
+                unmatched_names.append(name)
+        if matching_regexes:
+            print("Found at least one matching rule for malpedia family {}".format(family))
+            print("    malpedia names: {}".format(names))
+            print("    rules:          {}".format(list(set(matching_regexes))))
+        if unmatched_names:
+            print("No mapping for names '{}' of malpedia entry {}.".format("', '".join(unmatched_names), family))
+
+
+def main():
+    parser = argparse.ArgumentParser(prog='check_malpedia', description='Checks if malpedia lists malware names which this mapping does not support.')
+    parser.add_argument('-o', '--online', action='store_true', help='Check online against the Malpedia REST-API.')
+    parser.add_argument('-u', '--username', type=str, default="", help='Malpedia Username (for online mode).')
+    parser.add_argument('-p', '--password', type=str, default="", help='Malpedia Password (for online mode).')
+    parser.add_argument('-m', '--malpedia_root', type=str, default="", help='Check offline against the Malpedia repository.')
+    args = parser.parse_args()
+    
+    malpedia_names = {}
+    if args.malpedia_root:
+        malpedia_names = get_malpedia_names_offline(args.malpedia_root)
+    elif args.online and args.username and args.password:
+        malpedia_names = get_malpedia_names_online(args.username, args.password)
+    else:
+        parser.print_help()
+    
+    mapping = load_mapping()
+    check_mapping_regexes(mapping, malpedia_names)
+    
+    
+if __name__ == "__main__":
+    sys.exit(main())
+


### PR DESCRIPTION
Hi,
I've extended the check-malpedia script with an offline mode (to check against a checked out repo), which is way faster. 
I've also added output for matched regexes that can be used to check the other direction, i.e. name covered by regex but not in malpedia. 
Best Regards
Daniel