### PR TITLE
Changes for rovnix, gozi, vundo

### DIFF
--- a/mapping.csv
+++ b/mapping.csv
@@ -14,11 +14,11 @@
 "^(b67-ss-|avalanche-)?nymai[mn]$",nymaim,spamhaus,shadowserver,microsoft
 "^(b67-ss-|avalanche-)?panda-?banker$",zeus,https://www.proofpoint.com/us/threat-insight/post/zeus-panda-banking-trojan-targets-online-holiday-shoppers shadowserver,microsoft
 "^(b67-ss-|avalanche-)?ranbyus$",ranbyus,shadowserver,microsoft
-"^(b67-ss-|avalanche-)?rovnix$",rovnix,shadowserver,microsoft
+"^(b67-ss-|avalanche-)rovnix$",reactorbot,shadowserver,microsoft
 "^(b67-ss-|avalanche-)?teslacrypt$",teslacrypt,shadowserver,microsoft
 "^(b67-ss-|avalanche-)?tinba$",tinba,shadowserver,microsoft
 "^(b67-ss-|avalanche-)?urlzone2?$",urlzone,microsoft,bambenek,aka bebloh,shadowserver,microsoft
-"^(b67-ss-|avalanche-)?vawtrak$",vawtrak,shadowserver,microsoft,https://blog.trendmicro.com/trendlabs-security-intelligence/banking-malware-vawtrak-now-uses-malicious-macros-abuses-windows-powershell/
+"^(b67-ss-|avalanche-)?(vawtrak|neverquest)$",vawtrak,shadowserver,microsoft,https://blog.trendmicro.com/trendlabs-security-intelligence/banking-malware-vawtrak-now-uses-malicious-macros-abuses-windows-powershell/
 "^(b67-ss-|avalanche-)?xswkit$",gootkit,malpedia
 "^(b67-ss-|avalanche-)?bolek$",bolek,microsoft,shadowserver
 "^(b46-http-[cm]|b93-(base|config|hd))$",caphaw,used by microsoft,https://csirt.cesnet.cz/_media/cs/services/x4/botnet_simda.pdf https://csirt.cesnet.cz/_media/cs/services/x4/botnet_caphaw.pdf
@@ -41,7 +41,7 @@
 "^downloaderbot-(mxb|2)$",downloader-bot,migrated from intelmq
 "^(feodo|dridex(-data)?|cridex|geodo|emote[dt]|heodo|bugat|sumax)$",feodo,malpedia,history and naming: https://feodotracker.abuse.ch/ https://en.wikipedia.org/wiki/Avalanche_(phishing_group)#Malware_deprived_of_infrastructure
 "^gameover[-_](zeus-)(dga|peer|p2p)$",zeus,migrated from intelmq
-"^(avalanche-?)?(gozi2?|(gozi )?crm|papras|snifula|ursnif)$",gozi,malpedia,shadowserver
+"^((avalanche-)?gozi2?|(gozi )?(isfb|crm)|papras|snifula|ursnif|dreambot)$",gozi,malpedia,shadowserver
 "^(avalanche-)?((p2p|vm)?zeus(_p2p|_gameover(_us)?|vm)?|botnet_certtw)$",zeus,migrated from intelmq,cert.pl
 "^ramnit(-0x[0-9a-f]*)?$",ramnit,migrated from intelmq
 "^sality([_-]?p2p)?(v)?[0-9]?$",sality,migrated from intelmq
@@ -57,7 +57,8 @@
 "^necurs(web)?$",necurs,malpedia
 "^kbot$",kbot,
 "^xpaj$",xpaj,
-"^(mayachok|cidox|bkloader)$",rovnix,malpedia
+"^(mayachok|cidox|vundo)$",vundo,microsoft,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=Win32%2FVundo
+"^(rovnix|bkloader)$",rovnix,
 "^(beebone|vobfus|vbofus|changeup|aaeh)$",aaeh,https://www.us-cert.gov/ncas/alerts/TA15-098A,https://aaeh.shadowserver.org/
 "^(unknown([0-9]{4})?|sinkhole|ransomware|infected|bitdefender-foreign|unknown-apt)$",malware-generic,spamhaus,cert.pl,shadowserver,
 "^(wannacry|wannacrypt)$",wannacry,shadowserver,https://en.wikipedia.org/wiki/WannaCry_ransomware_attack
@@ -121,7 +122,6 @@
 "^(infy(-apt)?|foudre)$",foudre,malpedia
 "^installmonster$",installmonster,adware
 "^installrex$",installrex,adware
-"^isfb$",gozi,malpedia
 "^newgoz$",zeus,https://github.com/baderj/domain_generation_algorithms#overview
 "^joinkjot$",joinkjot,
 "^(kelihos(c|\.e)?|hlux)$",kelihos,https://en.wikipedia.org/wiki/Kelihos_botnet


### PR DESCRIPTION
b67-ss-rovnix and avalanche-rovnix are actually reactorbot.
Add neverquest alias for vawtrak.
Merge gozi rules, add dreambot alias.
mayachok and cidox aliases changed to vundo.
bkloader alias changed to rovnix.
