### PR TITLE
Fix B106 mappings

### DIFF
--- a/mapping.csv
+++ b/mapping.csv
@@ -230,6 +230,7 @@
 "^(b106-)?bezigate$",bezigate,used by microsoft
 "^(b106-)?binder$",binder,used by microsoft
 "^(b106-)?bisar$",bisar,used by microsoft
+"^(b106)-?blohi",blohi,used by microsoft,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=Backdoor:Win32/Blohi.B
 "^(b106-)?browserpassview$",browserpassview,used by microsoft
 "^(b106-)?cakl$",cakl,used by microsoft
 "^(b106-)?cashback$",cashback,used by microsoft
@@ -244,12 +245,14 @@
 "^(b106-)?comrerop$",comrerop,used by microsoft
 "^(b106-)?comroki$",comroki,used by microsoft
 "^(b106-)?comsirig$",comsirig,used by microsoft
+"^(b106-)?coolvidoor$",coolvidoor,used by microsoft
 "^(b106-)?coremhead$",coremhead,used by microsoft
 "^(b106-)?crime$",crime,used by microsoft
 "^(b106-)?danglo$",danglo,used by microsoft,https://www.solvusoft.com/en/malware/viruses/troj-danglo-f/
 "^(b106-)?darkddoser$",darkddoser,used by microsoft
 "^(b106-)?darkmoon$",darkmoon,used by microsoft
 "^(b106-)?decay$",decay,used by microsoft
+"^(b106-)?defsel$",defsel,used by microsoft
 "^(b106-)?dimegup$",dimegup,used by microsoft
 "^(b106-)?dnr$",dnr,used by microsoft
 "^(b106-)?dokstormac$",dokstormac,used by microsoft
@@ -264,6 +267,7 @@
 "^((b106-)?frosparf|feis)$",frosparf,used by microsoft,https://www.solvusoft.com/en/malware/trojans/trojan-feis/
 "^(b106-)?(fynloski|klovbot)$",fynloski,malpedia,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=Backdoor:Win32/Fynloski.G
 "^(b106-)?gaobot$",gaobot,used by microsoft
+"^(b106-)?geratid$",geratid,used by microsoft,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=TrojanDropper%2525253aWin32%2525252fGeratid.A
 "^(b106-)?gernidru$",gernidru,used by microsoft
 "^(b106-)?geycript$",geycript,used by microsoft
 "^(b106-)?gratem$",gratem,used by microsoft
@@ -309,6 +313,7 @@
 "^(b106-)?noancooe$",noancooe,used by microsoft
 "^(b106-)?nosrawec$",nosrawec,used by microsoft
 "^(b106-)?nuqel$",nuqel,used by microsoft
+"^(b106-)?nusump$",nusump,used by microsoft,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=Worm:Win32/Nusump
 "^(b106-)?parama$",parama,used by microsoft
 "^(b106-)?parite$",parite,used by microsoft
 "^(b106-)?pcclient$",pcclient,used by microsoft
@@ -320,6 +325,7 @@
 "^(b106-)?prosti$",prosti,used by microsoft
 "^(b106-)?protos$",protos,used by microsoft
 "^(b106-)?pushbot$",pushbot,used by microsoft
+"^(b106-)?ramnit$",ramnit,used by microsoft
 "^(b106-)?ranos$",ranos,used by microsoft
 "^(b106-)?rbot$",rbot,used by microsoft
 "^(b106-)?rebhip$",cybergate,malpedia,used by microsoft
@@ -340,6 +346,7 @@
 "^(b106-)?spybot$",spybot,malpedia,used by microsoft
 "^(b106-)?squida$",squida,used by microsoft
 "^(b106-)?ssonce$",ssonce,used by microsoft
+"^(b106-)?sulunch$",sulunch,used by microsoft,https://en.wikipedia.org/wiki/Sulunch
 "^((b106-)?swisyn|roopirs|arhost|ashwho)$",swisyn,used by microsoft,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=Worm:Win32/Roopirs.A,https://www.solvusoft.com/en/malware/trojans/tr-swisyn-ubp-13/
 "^(b106-)?swrort$",swrort,used by microsoft
 "^(b106-)?synflood$",synflood,used by microsoft
@@ -362,6 +369,7 @@
 "^(b106-)?vbinject$",vbinject,used by microsoft
 "^(b106-)?vburses$",vburses,used by microsoft
 "^(b106-)?vharke$",vharke,used by microsoft
+"^(b106-)?vinject$",vinject,used by microsoft,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=Trojan:Win32/Vinject.A
 "^(b106-)?vonriamt$",vonriamt,used by microsoft
 "^(b106-)?vtub$",vtub,used by microsoft
 "^(b106-)?weenkay$",weenkay,used by microsoft

--- a/mapping.csv
+++ b/mapping.csv
@@ -2,7 +2,7 @@
 "^(b106-delfinject|delfin-?fam)$",delfinject,https://www.solvusoft.com/en/malware/viruses/troj-delfin-fam/,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=VirTool%3AWin32%2FInjector.gen!Z&Search=true
 "^(b106-)?otran$",otran,used by microsoft
 "^b54-(base|code|config|old|dga1)$",citadel,microsoft,https://csirt.cesnet.cz/_media/cs/services/x4/botnet_citadel.pdf
-"^b58-(chtoz|code1|crsh|dga1|dga2|(dns[1-5])|xplt)$",bamital,microsoft,https://csirt.cesnet.cz/_media/cs/services/x4/botnet_bamital.pdf
+"^b58-(chtoz|code1|crsh|dga1|dga2|(dns[1-5])|xplt|notc)$",bamital,microsoft,https://csirt.cesnet.cz/_media/cs/services/x4/botnet_bamital.pdf
 "^(avalanche-andromeda|andromeda-b66)$",andromeda,shadowserver,http://blog.shadowserver.org/2017/12/04/avalanche-year-two-this-time-with-andromeda/
 "^b66-(http(-unknown)?|exe)$",andromeda,microsoft
 "^(b6[67]{1}-ss-|andromeda |b106-)?gamarue$",andromeda,microsoft,malpedia,https://www.trendmicro.com/vinfo/us/threat-encyclopedia/malware/ANDROMEDA
@@ -24,7 +24,8 @@
 "^(b46-http-[cm]|b93-(base|config|hd))$",caphaw,used by microsoft,https://csirt.cesnet.cz/_media/cs/services/x4/botnet_simda.pdf https://csirt.cesnet.cz/_media/cs/services/x4/botnet_caphaw.pdf
 "^b157-([no]3|r[01L])$",zeus,used by microsoft,https://csirt.cesnet.cz/_media/cs/services/x4/botnet_gameoverzeus.pdf
 "^shylock$",caphaw,malpedia
-"^b68-(zeroaccess-)?(1|2)-(32|64)(bit)?(-supernode)?$",zeroaccess,microsoft,shadowserver,https://csirt.cesnet.cz/_media/cs/services/x4/botnet_zeroaccess.pdf
+"^b68-(zeroaccess-)?(1|2)-(32|64)(bit)?(-supernode)?$",zeroaccess,shadowserver,https://csirt.cesnet.cz/_media/cs/services/x4/botnet_zeroaccess.pdf
+"^b68-(dns|tcp)$",zeroaccess,microsoft,https://csirt.cesnet.cz/_media/cs/services/x4/botnet_zeroaccess.pdf
 "^zeroaccess$",zeroaccess,malpedia,https://en.wikipedia.org/wiki/ZeroAccess_botnet
 "^b75-s(1|12|2)$",ramnit,microsoft,https://csirt.cesnet.cz/_media/cs/services/x4/botnet_ramnit.pdf
 "^b85-r[1-2][sv]{1}$",dorkbot,https://csirt.cesnet.cz/_media/cs/services/x4/botnet_dorkbot.pdf

--- a/mapping.csv
+++ b/mapping.csv
@@ -214,7 +214,6 @@
 "^(b106-)?ainslot$",ainslot,used by microsoft
 "^(b106-)?amighelo$",amighelo,used by microsoft
 "^(b106-)?ardamax$",ardamax,used by microsoft,malpedia
-"^(b106-)?(arhost|swisyn)$",swisyn,used by microsoft,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?name=WORM:WIN32/ARHOST.A
 "^(b106-)?assasin$",assasin,used by microsoft
 "^(b106-)?autoac$",autoac,used by microsoft
 "^(b106-)?autinject$",autinject,used by microsoft
@@ -230,7 +229,7 @@
 "^(b106-)?bezigate$",bezigate,used by microsoft
 "^(b106-)?binder$",binder,used by microsoft
 "^(b106-)?bisar$",bisar,used by microsoft
-"^(b106)-?blohi",blohi,used by microsoft,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=Backdoor:Win32/Blohi.B
+"^(b106)?-blohi$",blohi,used by microsoft,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=Backdoor:Win32/Blohi.B
 "^(b106-)?browserpassview$",browserpassview,used by microsoft
 "^(b106-)?cakl$",cakl,used by microsoft
 "^(b106-)?cashback$",cashback,used by microsoft
@@ -283,7 +282,6 @@
 "^(b106-)?itsproc$",itsproc,used by microsoft
 "^(b106-)?kilim$",kilim,used by microsoft
 "^(b106-)?kkmaka$",kkmaka,used by microsoft
-"^(b106-)?klovbot$",klovbot,used by microsoft
 "^(b106-)?knowlog$",knowlog,used by microsoft
 "^(b106-)?lenc$",lenc,used by microsoft
 "^(b106-)?leodon$",leodon,used by microsoft
@@ -325,7 +323,7 @@
 "^(b106-)?prosti$",prosti,used by microsoft
 "^(b106-)?protos$",protos,used by microsoft
 "^(b106-)?pushbot$",pushbot,used by microsoft
-"^(b106-)?ramnit$",ramnit,used by microsoft
+"^b106-ramnit$",ramnit,used by microsoft
 "^(b106-)?ranos$",ranos,used by microsoft
 "^(b106-)?rbot$",rbot,used by microsoft
 "^(b106-)?rebhip$",cybergate,malpedia,used by microsoft

--- a/mapping.csv
+++ b/mapping.csv
@@ -1,5 +1,6 @@
-"^b106-(bladabindi|cb|(cee|vb)?inject|chuchelo|darkddoser|dimegup|dynamer|fynloski|jenxcus|multi|injector|xtrat|netwiredrc|vobfus|malagent|meredrop|ainslot|bifrose|ceatrg|rbot|comitsproc|poison|msposer|sormoeck|crime|keylogger|rebhip|remhead|sisron|pontoeb|mielit|comrerop|dusvext|habbo|necast|tobfy|wervik|hanictik|hupigon|toobtox)$",bladabindi/jenxcus,used by microsoft,https://csirt.cesnet.cz/_media/cs/services/x4/botnet_b106.pdf
-"^(b106-delfinject|delfin-?fam)$",delfinject,https://www.solvusoft.com/en/malware/viruses/troj-delfin-fam/,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=VirTool%3AWin32%2FInjector.gen!Z&Search=true
+"^b106-(bladabindi|cb|jenxcus)$",bladabindi/jenxcus,used by microsoft,https://csirt.cesnet.cz/_media/cs/services/x4/botnet_b106.pdf
+"^delf(inject|in-?fam)?$",delfinject,https://www.solvusoft.com/en/malware/viruses/troj-delfin-fam/
+"^b106-delf(snif|inject)?$",delfinject,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=VirTool%3AWin32%2FInjector.gen!Z
 "^(b106-)?otran$",otran,used by microsoft
 "^b54-(base|code|config|old|dga1)$",citadel,microsoft,https://csirt.cesnet.cz/_media/cs/services/x4/botnet_citadel.pdf
 "^b58-(chtoz|code1|crsh|dga1|dga2|(dns[1-5])|xplt|notc)$",bamital,microsoft,https://csirt.cesnet.cz/_media/cs/services/x4/botnet_bamital.pdf
@@ -60,10 +61,10 @@
 "^xpaj$",xpaj,
 "^(mayachok|cidox|vundo)$",vundo,microsoft,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=Win32%2FVundo
 "^(rovnix|bkloader)$",rovnix,
-"^(beebone|vobfus|vbofus|changeup|aaeh)$",aaeh,https://www.us-cert.gov/ncas/alerts/TA15-098A,https://aaeh.shadowserver.org/
+"^(beebone|(b106-)?vobfus|vbofus|changeup|aaeh)$",aaeh,microsoft,https://www.us-cert.gov/ncas/alerts/TA15-098A,https://aaeh.shadowserver.org/
 "^(unknown([0-9]{4})?|sinkhole|ransomware|infected|bitdefender-foreign|unknown-apt|s_other)$",malware-generic,spamhaus,cert.pl,shadowserver
 "^(wannacry|wannacrypt)$",wannacry,shadowserver,https://en.wikipedia.org/wiki/WannaCry_ransomware_attack
-"^zegost$",zegost,spamhaus,shadowserver
+"^(b106-)?zegost$",zegost,spamhaus,shadowserver,microsoft
 "^(torpig|anserin|sinowal)$",torpig,shadowserver,spamhaus,https://en.wikipedia.org/wiki/Torpig
 "^(sphinx|anubisspy)$",zeus,https://www.trendmicro.com/vinfo/us/security/news/cybercrime-and-digital-threats/sphinx-scammers-got-scammed,https://blog.trendmicro.com/trendlabs-security-intelligence/cyberespionage-campaign-sphinx-goes-mobile-anubisspy/
 "^(zeus_)?panda$",zeus,shadowserver
@@ -82,8 +83,8 @@
 "^bamital$",bamital,
 "^(banjori|bankpatch|backpatcher|multibanker 2)$",banjori,malpedia
 "^bedep$",bedep,
-"^(betabot|neurevt)$",betabot,malpedia
-"^bifrose$",bifrose,
+"^(betabot|(b106-)?neurevt)$",betabot,malpedia,microsoft
+"^(b106-)?bifrose$",bifrose,
 "^bitcoinminer$",bitcoinminer,
 "^blakamba$",blakamba,
 "^(bondat|jsproslikefan)$",bondat,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=JS/Bondat
@@ -128,7 +129,7 @@
 "^(kelihos(c|\.e)?|hlux)$",kelihos,https://en.wikipedia.org/wiki/Kelihos_botnet
 "^kronos$",kronos,https://en.wikipedia.org/wiki/Kronos_(malware)
 "^kuguo$",kuguo,adware,on android
-"^ldpinch$",ldpinch,
+"^(b106-)?ldpinch$",ldpinch,microsoft
 "^lethic$",lethic,malpedia
 "^locky$",locky,malpedia
 "^machbot$",machbot,
@@ -198,9 +199,6 @@
 "^ebury$",ebury,https://www.cert-bund.de/ebury-faq
 "^tofsee$",tofsee,shadowserver,microsoft,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?name=Win32/Tofsee
 "^srizbi$",srizbi,https://en.wikipedia.org/wiki/Srizbi_botnet
-"^b106-danglo$",danglo,used by microsoft,https://www.solvusoft.com/en/malware/viruses/troj-danglo-f/
-"^b106-tapazom$",tapazom,used by microsoft
-"^b106-agentbypass$",agentbypass,used by microsoft
 "^ponmocup$",ponmocup,shadowserver,spamhaus,https://foxitsecurity.files.wordpress.com/2015/12/foxit-whitepaper_ponmocup_1_1.pdf
 "^pitou$",pitou,malpedia
 "^sisron$",sisron,malpedia
@@ -208,3 +206,155 @@
 "^mumblehard$",mumblehard,
 "^spyapp$",spyapp-generic,anubis,on android,
 "^wauchos$",wauchos,shadowserver,
+"^b106-(autorun|inject(or)?|ircbot|ircbrute|keylogger|multi|obfuscator|possiblemalware|small)$",malware-generic,used by microsoft
+"^(solarbot|b106-napolar)$",solarbot,malpedia,used by microsoft
+"^(b106-)?poison_?ivy$",poison_ivy,malpedia,used by microsoft
+"^(b106-)?agentbypass$",agentbypass,used by microsoft
+"^(b106-)?ainslot$",ainslot,used by microsoft
+"^(b106-)?amighelo$",amighelo,used by microsoft
+"^(b106-)?ardamax$",ardamax,used by microsoft,malpedia
+"^(b106-)?assasin$",assasin,used by microsoft
+"^(b106-)?autoac$",autoac,used by microsoft
+"^(b106-)?balidor$",balidor,used by microsoft
+"^(b106-)?bancos$",bancos,used by microsoft
+"^(b106-)?bandok$",bandok,used by microsoft
+"^(b106-)?banker$",banker,used by microsoft
+"^(b106-)?banload$",banload,used by microsoft
+"^(b106-)?bariori$",bariori,used by microsoft
+"^(b106-)?beastdoor$",beastdoor,used by microsoft
+"^(b106-)?beaugrit$",beaugrit,used by microsoft
+"^(b106-)?bexelets$",bexelets,used by microsoft
+"^(b106-)?bezigate$",bezigate,used by microsoft
+"^(b106-)?binder$",binder,used by microsoft
+"^(b106-)?bisar$",bisar,used by microsoft
+"^(b106-)?browserpassview$",browserpassview,used by microsoft
+"^(b106-)?cakl$",cakl,used by microsoft
+"^(b106-)?cashback$",cashback,used by microsoft
+"^(b106-)?ceatrg$",ceatrg,used by microsoft
+"^(b106-)?cechip$",cechip,used by microsoft
+"^(b106-)?ceeinject$",ceeinject,used by microsoft
+"^(b106-)?chuchelo$",chuchelo,used by microsoft
+"^(b106-)?chir$",chir,malepdia,used by microsoft
+"^(b106-)?comame$",comame,used by microsoft
+"^(b106-)?comisproc$",comisproc,used by microsoft
+"^(b106-)?comitsproc$",comitsproc,used by microsoft
+"^(b106-)?comrerop$",comrerop,used by microsoft
+"^(b106-)?comroki$",comroki,used by microsoft
+"^(b106-)?comsirig$",comsirig,used by microsoft
+"^(b106-)?coremhead$",coremhead,used by microsoft
+"^(b106-)?crime$",crime,used by microsoft
+"^(b106-)?danglo$",danglo,used by microsoft,https://www.solvusoft.com/en/malware/viruses/troj-danglo-f/
+"^(b106-)?darkddoser$",darkddoser,used by microsoft
+"^(b106-)?darkmoon$",darkmoon,used by microsoft
+"^(b106-)?decay$",decay,used by microsoft
+"^(b106-)?dimegup$",dimegup,used by microsoft
+"^(b106-)?dnr$",dnr,used by microsoft
+"^(b106-)?dokstormac$",dokstormac,used by microsoft
+"^(b106-)?dooxud$",dooxud,used by microsoft
+"^(b106-)?dorkbot$",dorkbot,microsoft
+"^(b106-)?dusvext$",dusvext,used by microsoft
+"^(b106-)?dynamer$",dynamer,used by microsoft
+"^(b106-)?effbee$",effbee,used by microsoft
+"^(b106-)?eyestye$",eyestye,used by microsoft
+"^(b106-)?farfli$",farfli,used by microsoft
+"^(b106-)?folyris$",folyris,used by microsoft
+"^(b106-)?fynloski$",fynloski,malpedia
+"^(b106-)?gaobot$",gaobot,used by microsoft
+"^(b106-)?gernidru$",gernidru,used by microsoft
+"^(b106-)?geycript$",geycript,used by microsoft
+"^(b106-)?gratem$",gratem,used by microsoft
+"^(b106-)?gspot$",gspot,used by microsoft
+"^(b106-)?habbo$",habbo,used by microsoft
+"^(b106-)?hamweq$",hamweq,malpedia
+"^(b106-)?hanictik$",hanictik,used by microsoft
+"^(b106-)?hiderun$",hiderun,used by microsoft
+"^(b106-)?histboader$",histboader,used by microsoft
+"^(b106-)?horsamaz$",horsamaz,used by microsoft
+"^(b106-)?hoygunver$",hoygunver,used by microsoft
+"^(b106-)?hupigon$",hupigon,used by microsoft
+"^(b106-)?itsproc$",itsproc,used by microsoft
+"^(b106-)?kilim$",kilim,used by microsoft
+"^(b106-)?kkmaka$",kkmaka,used by microsoft
+"^(b106-)?knowlog$",knowlog,used by microsoft
+"^(b106-)?leodon$",leodon,used by microsoft
+"^(b106-)?levitiang$",levitiang,used by microsoft
+"^(b106-)?lybsus$",lybsus,used by microsoft
+"^(b106-)?lypsacop$",lypsacop,used by microsoft
+"^(b106-)?malagent$",malagent,used by microsoft
+"^(b106-)?malex$",malex,used by microsoft
+"^(b106-)?meredrop$",meredrop,used by microsoft
+"^(b106-)?mielit$",mielit,used by microsoft
+"^(b106-)?misbot$",misbot,used by microsoft
+"^(b106-)?mobibez$",mobibez,used by microsoft
+"^(b106-)?mosripe$",mosripe,used by microsoft
+"^(b106-)?mosucker$",mosucker,used by microsoft
+"^(b106-)?msposer$",msposer,used by microsoft
+"^(b106-)?naprat$",naprat,used by microsoft
+"^(b106-)?nayrabot$",nayrabot,used by microsoft
+"^(b106-)?necast$",necast,used by microsoft
+"^(b106-)?neeris$",neeris,used by microsoft
+"^(b106-)?nemim$",nemim,used by microsoft
+"^(b106-)?neshta$",neshta,used by microsoft
+"^(b106-)?netbot$",netbot,used by microsoft
+"^(b106-)?netwiredrc$",netwiredrc,used by microsoft
+"^(b106-)?noancooe$",noancooe,used by microsoft
+"^(b106-)?nosrawec$",nosrawec,used by microsoft
+"^(b106-)?nuqel$",nuqel,used by microsoft
+"^(b106-)?parama$",parama,used by microsoft
+"^(b106-)?parite$",parite,used by microsoft
+"^(b106-)?pcclient$",pcclient,used by microsoft
+"^(b106-)?pdfjsc$",pdfjsc,used by microsoft
+"^(b106-)?poison$",poison,used by microsoft
+"^(b106-)?pontoeb$",pontoeb,used by microsoft
+"^(b106-)?prorat$",prorat,used by microsoft
+"^(b106-)?prosti$",prosti,used by microsoft
+"^(b106-)?protos$",protos,used by microsoft
+"^(b106-)?pushbot$",pushbot,used by microsoft
+"^(b106-)?ranos$",ranos,used by microsoft
+"^(b106-)?rbot$",rbot,used by microsoft
+"^(b106-)?rebhip$",cybergate,malpedia,used by microsoft
+"^(b106-)?remhead$",remhead,used by microsoft
+"^(b106-)?rimod$",rimod,used by microsoft
+"^(b106-)?ritros$",ritros,used by microsoft
+"^(b106-)?runner$",runner,used by microsoft
+"^(b106-)?scar$",scar,used by microsoft
+"^(b106-)?sdbot$",sdbot,used by microsoft
+"^(b106-)?sharke$",sharke,used by microsoft
+"^(b106-)?silby$",silby,used by microsoft
+"^(b106-)?sillysharecopy$",sillysharecopy,used by microsoft
+"^(b106-)?sisproc$",sisproc,used by microsoft
+"^(b106-)?sisron$",sisron,used by microsoft
+"^(b106-)?skypams$",skypams,used by microsoft
+"^(b106-)?sormoeck$",sormoeck,used by microsoft
+"^(b106-)?splori$",splori,used by microsoft
+"^(b106-)?spybot$",spybot,malpedia,used by microsoft
+"^(b106-)?squida$",squida,used by microsoft
+"^(b106-)?ssonce$",ssonce,used by microsoft
+"^(b106-)?swrort$",swrort,used by microsoft
+"^(b106-)?synflood$",synflood,used by microsoft
+"^(b106-)?tapazom$",tapazom,used by microsoft
+"^(b106-)?tawsebot$",tawsebot,used by microsoft
+"^(b106-)?tearspear$",tearspear,used by microsoft
+"^(b106-)?tendrit$",tendrit,used by microsoft
+"^(b106-)?tenpeq$",tenpeq,used by microsoft
+"^(b106-)?tobfy$",tobfy,used by microsoft
+"^(b106-)?tocofob$",tocofob,used by microsoft
+"^(b106-)?toobtox$",toobtox,used by microsoft
+"^(b106-)?tumpadex$",tumpadex,used by microsoft
+"^(b106-)?turkojan$",turkojan,used by microsoft
+"^(b106-)?twores$",twores,used by microsoft
+"^(b106-)?vahodon$",vahodon,used by microsoft
+"^(b106-)?vake$",vake,used by microsoft
+"^(b106-)?vb$",adclicker,used by microsoft,other name because vb is too generic,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=Trojan:Win32/VB
+"^(b106-)?vbcrypt$",vbcrypt,used by microsoft
+"^(b106-)?vbinder$",vbinder,used by microsoft
+"^(b106-)?vbinject$",vbinject,used by microsoft
+"^(b106-)?vburses$",vburses,used by microsoft
+"^(b106-)?vonriamt$",vonriamt,used by microsoft
+"^(b106-)?vtub$",vtub,used by microsoft
+"^(b106-)?weenkay$",weenkay,used by microsoft
+"^(b106-)?wervik$",wervik,used by microsoft
+"^(b106-)?xtrat$",xtrat,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?name=BACKDOOR:WIN32/XTRAT.A
+"^(b106-)?xyligan$",xyligan,used by microsoft
+"^(b106-)?yemrok$",yemrok,used by microsoft
+"^(b106-)?zacusca$",zacusca,used by microsoft

--- a/mapping.csv
+++ b/mapping.csv
@@ -206,7 +206,7 @@
 "^mumblehard$",mumblehard,
 "^spyapp$",spyapp-generic,anubis,on android,
 "^wauchos$",wauchos,shadowserver,
-"^b106-(autorun|inject(or)?|ircbot|ircbrute|keylogger|multi|obfuscator|possiblemalware|small)$",malware-generic,used by microsoft
+"^b106-(agent|autorun|inject(or)?|ircbot|ircbrute|keylogger|multi|obfuscator|possiblemalware|small)$",malware-generic,used by microsoft
 "^(solarbot|b106-napolar)$",solarbot,malpedia,used by microsoft
 "^(b106-)?poison_?ivy$",poison_ivy,malpedia,used by microsoft
 "^(b106-)?agentbypass$",agentbypass,used by microsoft
@@ -215,6 +215,7 @@
 "^(b106-)?ardamax$",ardamax,used by microsoft,malpedia
 "^(b106-)?assasin$",assasin,used by microsoft
 "^(b106-)?autoac$",autoac,used by microsoft
+"^(b106-)?autoinject$",autoinject,used by microsoft
 "^(b106-)?balidor$",balidor,used by microsoft
 "^(b106-)?bancos$",bancos,used by microsoft
 "^(b106-)?bandok$",bandok,used by microsoft
@@ -258,7 +259,8 @@
 "^(b106-)?eyestye$",eyestye,used by microsoft
 "^(b106-)?farfli$",farfli,used by microsoft
 "^(b106-)?folyris$",folyris,used by microsoft
-"^(b106-)?fynloski$",fynloski,malpedia
+"^((b106-)?frosparf|feis)$",frosparf,used by microsoft,https://www.solvusoft.com/en/malware/trojans/trojan-feis/
+"^(b106-)?(fynloski|klovbot)$",fynloski,malpedia,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=Backdoor:Win32/Fynloski.G
 "^(b106-)?gaobot$",gaobot,used by microsoft
 "^(b106-)?gernidru$",gernidru,used by microsoft
 "^(b106-)?geycript$",geycript,used by microsoft
@@ -276,10 +278,12 @@
 "^(b106-)?kilim$",kilim,used by microsoft
 "^(b106-)?kkmaka$",kkmaka,used by microsoft
 "^(b106-)?knowlog$",knowlog,used by microsoft
+"^(b106-)?lenc$",lenc,used by microsoft
 "^(b106-)?leodon$",leodon,used by microsoft
 "^(b106-)?levitiang$",levitiang,used by microsoft
 "^(b106-)?lybsus$",lybsus,used by microsoft
 "^(b106-)?lypsacop$",lypsacop,used by microsoft
+"^(b106-)?mafod$",mafod,used by microsoft,spyware,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=TrojanSpy:Win32/Mafod,https://www.solvusoft.com/en/malware/spyware/win32-mafod/
 "^(b106-)?malagent$",malagent,used by microsoft
 "^(b106-)?malex$",malex,used by microsoft
 "^(b106-)?meredrop$",meredrop,used by microsoft
@@ -294,9 +298,11 @@
 "^(b106-)?necast$",necast,used by microsoft
 "^(b106-)?neeris$",neeris,used by microsoft
 "^(b106-)?nemim$",nemim,used by microsoft
+"^(b106-)?neop$",neop,used by microsoft
 "^(b106-)?neshta$",neshta,used by microsoft
 "^(b106-)?netbot$",netbot,used by microsoft
 "^(b106-)?netwiredrc$",netwiredrc,used by microsoft
+"^(b106-)?nitol$",nitol,used by microsoft,malpedia
 "^(b106-)?noancooe$",noancooe,used by microsoft
 "^(b106-)?nosrawec$",nosrawec,used by microsoft
 "^(b106-)?nuqel$",nuqel,used by microsoft
@@ -306,6 +312,7 @@
 "^(b106-)?pdfjsc$",pdfjsc,used by microsoft
 "^(b106-)?poison$",poison,used by microsoft
 "^(b106-)?pontoeb$",pontoeb,used by microsoft
+"^(b106-)?popiidor$",popiidor,used by microsoft
 "^(b106-)?prorat$",prorat,used by microsoft
 "^(b106-)?prosti$",prosti,used by microsoft
 "^(b106-)?protos$",protos,used by microsoft
@@ -325,11 +332,13 @@
 "^(b106-)?sisproc$",sisproc,used by microsoft
 "^(b106-)?sisron$",sisron,used by microsoft
 "^(b106-)?skypams$",skypams,used by microsoft
+"^(b106-)?smpdoss$",smpdoss,used by microsoft
 "^(b106-)?sormoeck$",sormoeck,used by microsoft
 "^(b106-)?splori$",splori,used by microsoft
 "^(b106-)?spybot$",spybot,malpedia,used by microsoft
 "^(b106-)?squida$",squida,used by microsoft
 "^(b106-)?ssonce$",ssonce,used by microsoft
+"^((b106-)?swisyn|roopirs|arhost|ashwho)$",swisyn,used by microsoft,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=Worm:Win32/Roopirs.A,https://www.solvusoft.com/en/malware/trojans/tr-swisyn-ubp-13/
 "^(b106-)?swrort$",swrort,used by microsoft
 "^(b106-)?synflood$",synflood,used by microsoft
 "^(b106-)?tapazom$",tapazom,used by microsoft
@@ -350,6 +359,7 @@
 "^(b106-)?vbinder$",vbinder,used by microsoft
 "^(b106-)?vbinject$",vbinject,used by microsoft
 "^(b106-)?vburses$",vburses,used by microsoft
+"^(b106-)?vharke$",vharke,used by microsoft
 "^(b106-)?vonriamt$",vonriamt,used by microsoft
 "^(b106-)?vtub$",vtub,used by microsoft
 "^(b106-)?weenkay$",weenkay,used by microsoft

--- a/mapping.csv
+++ b/mapping.csv
@@ -207,7 +207,7 @@
 "^mumblehard$",mumblehard,
 "^spyapp$",spyapp-generic,anubis,on android,
 "^wauchos$",wauchos,shadowserver,
-"^b106-(agent|autorun|inject(or)?|ircbot|ircbrute|keylogger|multi|obfuscator|possiblemalware|small)$",malware-generic,used by microsoft
+"^b106-(agent|autorun|inject(or)?|ircbot|ircbrute|keygen|keylogger|multi|obfuscator|possiblemalware|small)$",malware-generic,used by microsoft
 "^(solarbot|b106-napolar)$",solarbot,malpedia,used by microsoft
 "^(b106-)?poison_?ivy$",poison_ivy,malpedia,used by microsoft
 "^(b106-)?agentbypass$",agentbypass,used by microsoft
@@ -345,7 +345,7 @@
 "^(b106-)?squida$",squida,used by microsoft
 "^(b106-)?ssonce$",ssonce,used by microsoft
 "^(b106-)?sulunch$",sulunch,used by microsoft,https://en.wikipedia.org/wiki/Sulunch
-"^((b106-)?swisyn|roopirs|arhost|ashwho)$",swisyn,used by microsoft,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=Worm:Win32/Roopirs.A,https://www.solvusoft.com/en/malware/trojans/tr-swisyn-ubp-13/
+"^((b106-)?(swisyn|arhost)|roopirs|ashwho)$",swisyn,used by microsoft,https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=Worm:Win32/Roopirs.A,https://www.solvusoft.com/en/malware/trojans/tr-swisyn-ubp-13/
 "^(b106-)?swrort$",swrort,used by microsoft
 "^(b106-)?synflood$",synflood,used by microsoft
 "^(b106-)?tapazom$",tapazom,used by microsoft

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-output=$(egrep -v '^"\^[^"]*\$",[0-9a-z/-]*,(.*)?$' mapping.csv)
+output=$(egrep -v '^"\^[^"]*\$",[0-9a-z/_-]*,(.*)?$' mapping.csv)
 if [ "$output" == "" ]; then
     exit 0
 else


### PR DESCRIPTION
cc @th-certbund 

Cleans up the existing mapping and adds are (to me) known malware names for b106.
Also adds a few mappings to malware-generic.